### PR TITLE
Unlock Crop Bug fixed

### DIFF
--- a/nordlingmod_server.lua
+++ b/nordlingmod_server.lua
@@ -26,4 +26,15 @@ else
   log:error("Couldn't Load Job Component")
 end
 
+local JobService = require 'stonehearth.services.server.job.job_service'
+local old_get_job_info = JobService.get_job_info
+function JobService:get_job_info(player_id, job_id)
+    local kingdom = stonehearth.player:get_kingdom(player_id)
+    if kingdom == "nordlingmod:kingdoms:nordlings" and job_id == "stonehearth:jobs:farmer" then
+     return old_get_job_info(self, player_id, "stonehearth:jobs:worker")
+   else
+     return old_get_job_info(self, player_id, job_id)
+  end
+end
+  log:error("Monkey Patched Job Service")
 --e:get_component("stonehearth:job"):level_up()


### PR DESCRIPTION
roles ect. being part of the worker now) attempts to get_job_info for
farms (e.g. when unlocking new crops) were crashing. This issues is
fixed simply by highjacking that request and switching the target away
from farmer and to worker (only for nordlings).

This allows both nordlings and non-nordlings to unlock crops correctly